### PR TITLE
Barnsley Mandelbrot set renderers

### DIFF
--- a/svitava.c
+++ b/svitava.c
@@ -1938,7 +1938,6 @@ int render_barnsley_m1(const image_t *image, const unsigned char *palette,
  * * cy + zy * cx). The number of iterations before escape (or reaching maxiter)
  * determines the color index for each pixel.
  *
- *
  * @returns NULL_IMAGE_POINTER when the input image is NULL
  *          NULL_PIXELS_POINTER when pixels are not allocated,
  *          NULL_PALETTE_POINTER when the palette is NULL
@@ -1989,6 +1988,77 @@ int render_barnsley_m2(const image_t *image, const unsigned char *palette,
                 } else {
                     zxn = zx * cx - zy * cy + cx;
                     zyn = zx * cy + zy * cx + cy;
+                }
+                zx = zxn;
+                zy = zyn;
+                i++;
+            }
+            putpixel(&p, palette, i % 256);
+            cx += step_x;
+        }
+        cy += step_y;
+    }
+    return OK;
+}
+
+/**
+ * Renders the Barnsley Mandelbrot-type fractal (variant m3) into a pixel buffer.
+ *
+ * Iterates a piecewise quadratic function over the complex plane for each
+ * pixel, with the function's behavior depending on the sign of the real part of
+ * z. Colors are assigned based on the number of iterations before escape, up to
+ * `maxiter`.
+ *
+ * @returns NULL_IMAGE_POINTER when the input image is NULL
+ *          NULL_PIXELS_POINTER when pixels are not allocated,
+ *          NULL_PALETTE_POINTER when the palette is NULL
+ *          INVALID_IMAGE_TYPE for images that are not of type RGBA
+ *          INVALID_IMAGE_DIMENSION if image has zero width/height
+ *          OK otherwise
+ */
+int render_barnsley_m3(const image_t *image, const unsigned char *palette,
+                        double zx0, double zy0, int maxiter) {
+    int            x, y;
+    double         cx, cy;
+    double         xmin = -2.0, ymin = -2.0, xmax = 2.0, ymax = 2.0;
+    double         step_x;
+    double         step_y;
+    unsigned char *p;
+
+    /* Only properly-created images are accepted */
+    ENSURE_PROPER_IMAGE_STRUCTURE
+    ENSURE_NON_EMPTY_IMAGE
+    ENSURE_PROPER_PALETTE
+
+    /* putpixel() writes 4 bytes per pixel, so only RGBA images are supported */
+    if (image->bpp != RGBA) {
+        return INVALID_IMAGE_TYPE;
+    }
+
+    p = image->pixels;
+    step_x = (xmax - xmin) / image->width;
+    step_y = (ymax - ymin) / image->height;
+
+    cy = ymin;
+    for (y = 0; y < image->height; y++) {
+        cx = xmin;
+        for (x = 0; x < image->width; x++) {
+            double       zx = zx0;
+            double       zy = zy0;
+            unsigned int i = 0;
+            while (i < maxiter) {
+                double zx2 = zx * zx;
+                double zy2 = zy * zy;
+                double zxn, zyn;
+                if (zx2 + zy2 > 4.0) {
+                    break;
+                }
+                if (zx > 0) {
+                    zxn = zx2 - zy2 - 1;
+                    zyn = 2.0 * zx * zy;
+                } else {
+                    zxn = zx2 - zy2 - 1 + cx * zx;
+                    zyn = 2.0 * zx * zy + cy * zx;
                 }
                 zx = zxn;
                 zy = zyn;
@@ -2055,6 +2125,10 @@ int main(int argc, char **argv) {
     image_clear(&image);
     render_barnsley_m2(&image, palette, 0, 0, 1000);
     image_export_ppm_binary(WIDTH, HEIGHT, image.pixels, "barnsley_m2.ppm");
+
+    image_clear(&image);
+    render_barnsley_m3(&image, palette, 0, 0, 1000);
+    image_export_ppm_binary(WIDTH, HEIGHT, image.pixels, "barnsley_m3.ppm");
 
     return 0;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three Barnsley Mandelbrot-style fractal renders (m1, m2, m3).
  * Users can specify initial coordinates, iteration limit, and color palette to generate each fractal.
  * Each run exports results as barnsley_m1.ppm, barnsley_m2.ppm, and barnsley_m3.ppm for easy viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->