### PR TITLE
Border pixels preservation tests

### DIFF
--- a/test.c
+++ b/test.c
@@ -2034,6 +2034,29 @@ void test_filter_smooth_3x3_gauss_grayscale_image(void) {
 }
 
 /**
+ * Test that filters preserve border pixels unchanged.
+ */
+void test_filter_smooth_3x3_gauss_preserves_border_pixels(void) {
+    TEST_BEGIN
+    image_t image = image_create(5, 5, RGB);
+    assert(image.pixels != NULL);
+    image_clear(&image);
+
+    /* Set a border pixel to a specific value */
+    image_putpixel(&image, 0, 0, 123, 45, 67, 255);
+
+    filter_smooth_3x3_gauss(&image);
+
+    /* Border pixel should remain unchanged (kernel doesn't cover it) */
+    unsigned char r, g, b, a;
+    image_getpixel(&image, 0, 0, &r, &g, &b, &a);
+    assert(r == 123 && g == 45 && b == 67);
+
+    free(image.pixels);
+    TEST_END
+}
+
+/**
  * Test filter_sharpen_3x3 with NULL image.
  */
 void test_filter_sharpen_3x3_null_image(void) {
@@ -2575,6 +2598,7 @@ int main(void) {
     test_filter_smooth_3x3_gauss_rgb_image();
     test_filter_smooth_3x3_gauss_rgba_image();
     test_filter_smooth_3x3_gauss_grayscale_image();
+    test_filter_smooth_3x3_gauss_preserves_border_pixels();
 
     test_filter_sharpen_3x3_null_image();
     test_filter_sharpen_3x3_image_without_pixels();

--- a/test.c
+++ b/test.c
@@ -2165,6 +2165,29 @@ void test_filter_sharpen_3x3_grayscale_image(void) {
 }
 
 /**
+ * Test that filters preserve border pixels unchanged.
+ */
+void test_filter_sharpen_3x3_preserves_border_pixels(void) {
+    TEST_BEGIN
+    image_t image = image_create(5, 5, RGB);
+    assert(image.pixels != NULL);
+    image_clear(&image);
+
+    /* Set a border pixel to a specific value */
+    image_putpixel(&image, 0, 0, 123, 45, 67, 255);
+
+    filter_sharpen_3x3(&image);
+
+    /* Border pixel should remain unchanged (kernel doesn't cover it) */
+    unsigned char r, g, b, a;
+    image_getpixel(&image, 0, 0, &r, &g, &b, &a);
+    assert(r == 123 && g == 45 && b == 67);
+
+    free(image.pixels);
+    TEST_END
+}
+
+/**
  * Verify that filter_edge_detection_3x3_1 does not crash when called with a NULL image.
  */
 void test_filter_edge_detection_3x3_1_null_image(void) {
@@ -2605,6 +2628,7 @@ int main(void) {
     test_filter_sharpen_3x3_rgb_image();
     test_filter_sharpen_3x3_rgba_image();
     test_filter_sharpen_3x3_grayscale_image();
+    test_filter_sharpen_3x3_preserves_border_pixels();
 
     test_filter_edge_detection_3x3_1_null_image();
     test_filter_edge_detection_3x3_1_image_without_pixels();

--- a/test.c
+++ b/test.c
@@ -2238,6 +2238,29 @@ void test_filter_edge_detection_3x3_1_rgb_image(void) {
 }
 
 /**
+ * Test that filters preserve border pixels unchanged.
+ */
+void test_filter_edge_detection_3x3_1_preserves_border_pixels(void) {
+    TEST_BEGIN
+    image_t image = image_create(5, 5, RGB);
+    assert(image.pixels != NULL);
+    image_clear(&image);
+
+    /* Set a border pixel to a specific value */
+    image_putpixel(&image, 0, 0, 123, 45, 67, 255);
+
+    filter_edge_detection_3x3_1(&image);
+
+    /* Border pixel should remain unchanged (kernel doesn't cover it) */
+    unsigned char r, g, b, a;
+    image_getpixel(&image, 0, 0, &r, &g, &b, &a);
+    assert(r == 123 && g == 45 && b == 67);
+
+    free(image.pixels);
+    TEST_END
+}
+
+/**
  * Test filter_edge_detection_3x3_2 with NULL image.
  */
 void test_filter_edge_detection_3x3_2_null_image(void) {
@@ -2633,6 +2656,7 @@ int main(void) {
     test_filter_edge_detection_3x3_1_null_image();
     test_filter_edge_detection_3x3_1_image_without_pixels();
     test_filter_edge_detection_3x3_1_rgb_image();
+    test_filter_edge_detection_3x3_1_preserves_border_pixels();
 
     test_filter_edge_detection_3x3_2_null_image();
     test_filter_edge_detection_3x3_2_image_without_pixels();

--- a/test.c
+++ b/test.c
@@ -1913,6 +1913,29 @@ void test_filter_smooth_3x3_block_grayscale_image(void) {
 }
 
 /**
+ * Test that filters preserve border pixels unchanged.
+ */
+void test_filter_smooth_3x3_preserves_border_pixels(void) {
+    TEST_BEGIN
+    image_t image = image_create(5, 5, RGB);
+    assert(image.pixels != NULL);
+    image_clear(&image);
+
+    /* Set a border pixel to a specific value */
+    image_putpixel(&image, 0, 0, 123, 45, 67, 255);
+
+    filter_smooth_3x3_block(&image);
+
+    /* Border pixel should remain unchanged (kernel doesn't cover it) */
+    unsigned char r, g, b, a;
+    image_getpixel(&image, 0, 0, &r, &g, &b, &a);
+    assert(r == 123 && g == 45 && b == 67);
+
+    free(image.pixels);
+    TEST_END
+}
+
+/**
  * Test filter_smooth_3x3_gauss with NULL image.
  */
 void test_filter_smooth_3x3_gauss_null_image(void) {
@@ -2545,6 +2568,7 @@ int main(void) {
     test_filter_smooth_3x3_block_rgb_image();
     test_filter_smooth_3x3_block_rgba_image();
     test_filter_smooth_3x3_block_grayscale_image();
+    test_filter_smooth_3x3_preserves_border_pixels();
 
     test_filter_smooth_3x3_gauss_null_image();
     test_filter_smooth_3x3_gauss_image_without_pixels();

--- a/test.c
+++ b/test.c
@@ -2372,6 +2372,29 @@ void test_filter_edge_detection_3x3_3_rgb_image(void) {
 }
 
 /**
+ * Test that filters preserve border pixels unchanged.
+ */
+void test_filter_edge_detection_3x3_3_preserves_border_pixels(void) {
+    TEST_BEGIN
+    image_t image = image_create(5, 5, RGB);
+    assert(image.pixels != NULL);
+    image_clear(&image);
+
+    /* Set a border pixel to a specific value */
+    image_putpixel(&image, 0, 0, 123, 45, 67, 255);
+
+    filter_edge_detection_3x3_3(&image);
+
+    /* Border pixel should remain unchanged (kernel doesn't cover it) */
+    unsigned char r, g, b, a;
+    image_getpixel(&image, 0, 0, &r, &g, &b, &a);
+    assert(r == 123 && g == 45 && b == 67);
+
+    free(image.pixels);
+    TEST_END
+}
+
+/**
  * Ensure filter_horizontal_edge_detection_3x3 safely handles a NULL image without crashing.
  */
 void test_filter_horizontal_edge_detection_3x3_null_image(void) {
@@ -2689,6 +2712,7 @@ int main(void) {
     test_filter_edge_detection_3x3_3_null_image();
     test_filter_edge_detection_3x3_3_image_without_pixels();
     test_filter_edge_detection_3x3_3_rgb_image();
+    test_filter_edge_detection_3x3_3_preserves_border_pixels();
 
     test_filter_horizontal_edge_detection_3x3_null_image();
     test_filter_horizontal_edge_detection_3x3_image_without_pixels();

--- a/test.c
+++ b/test.c
@@ -2306,6 +2306,29 @@ void test_filter_edge_detection_3x3_2_rgb_image(void) {
 }
 
 /**
+ * Test that filters preserve border pixels unchanged.
+ */
+void test_filter_edge_detection_3x3_2_preserves_border_pixels(void) {
+    TEST_BEGIN
+    image_t image = image_create(5, 5, RGB);
+    assert(image.pixels != NULL);
+    image_clear(&image);
+
+    /* Set a border pixel to a specific value */
+    image_putpixel(&image, 0, 0, 123, 45, 67, 255);
+
+    filter_edge_detection_3x3_2(&image);
+
+    /* Border pixel should remain unchanged (kernel doesn't cover it) */
+    unsigned char r, g, b, a;
+    image_getpixel(&image, 0, 0, &r, &g, &b, &a);
+    assert(r == 123 && g == 45 && b == 67);
+
+    free(image.pixels);
+    TEST_END
+}
+
+/**
  * Ensure filter_edge_detection_3x3_3 safely handles a NULL image without crashing.
  */
 void test_filter_edge_detection_3x3_3_null_image(void) {
@@ -2661,6 +2684,7 @@ int main(void) {
     test_filter_edge_detection_3x3_2_null_image();
     test_filter_edge_detection_3x3_2_image_without_pixels();
     test_filter_edge_detection_3x3_2_rgb_image();
+    test_filter_edge_detection_3x3_2_preserves_border_pixels();
 
     test_filter_edge_detection_3x3_3_null_image();
     test_filter_edge_detection_3x3_3_image_without_pixels();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify that image filter operations—including smooth, sharpen, and edge detection variants—preserve border pixel values when applied to images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->